### PR TITLE
run sandpaper::pin_version("MASS@7.3-59")

### DIFF
--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -27,11 +27,8 @@
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-57",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "71476c1d88d1ebdf31580e5a257d5d31",
-      "Requirements": []
+      "Version": "7.3-59",
+      "Source": "Repository"
     },
     "Matrix": {
       "Package": "Matrix",


### PR DESCRIPTION
The version of MASS in this repository was version 7.3-57, which fails in R with compillation errors:

```
 * installing *source* package ‘MASS’ ...
  ** package ‘MASS’ successfully unpacked and MD5 sums checked
  ** using staged installation
  ** libs
  using C compiler: ‘gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0’
  gcc -I"/usr/share/R/include" -DNDEBUG       -fpic  -g -O2 -ffile-prefix-map=/build/r-base-JhpCKt/r-base-4.3.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c MASS.c -o MASS.o
  MASS.c:37:23: error: unknown type name ‘Sint’; did you mean ‘uint’?
     37 | VR_sammon(double *dd, Sint *nn, Sint *kd, double *Y, Sint *niter,
        |                       ^~~~
        |                       uint
```

According to @mdsumner:

> those types were deprecated in R 4.3.0, it's some old legacy type for int - I
> expect you would need R prior to 4.3 for that version of MASS (before
> 7.3-57.1)

Unfortunately, using our usual method of `sandpaper::update_cache()` does not
work because it needs to provision the cache before it updates and the cache
cannot be provisioned for R version 3 because of the error above.

By using `sandpaper::pin_version("MASS@7.3-59")`, I am modifying `renv.lock` in
a static way to force the lesson to use the published working version of {MASS}.

